### PR TITLE
Multiple listener setup for vault-elb

### DIFF
--- a/modules/vault-elb/main.tf
+++ b/modules/vault-elb/main.tf
@@ -56,7 +56,7 @@ resource "aws_elb" "vault" {
   }
 
   health_check {
-    target              = "${var.health_check_protocol}:${var.health_check_port == 0 ? var.vault_api_port : var.health_check_port}${var.health_check_path}"
+    target              = "${var.health_check_protocol}:${var.health_check_port == 0 ? var.lb_healthcheck_vault_api_port : var.health_check_port}${var.health_check_path}"
     interval            = var.health_check_interval
     healthy_threshold   = var.health_check_healthy_threshold
     unhealthy_threshold = var.health_check_unhealthy_threshold

--- a/modules/vault-elb/main.tf
+++ b/modules/vault-elb/main.tf
@@ -37,13 +37,6 @@ resource "aws_elb" "vault" {
   }
 
   # Run the ELB in TCP passthrough mode
-  # listener {
-  #   lb_port           = var.lb_port
-  #   lb_protocol       = "TCP"
-  #   instance_port     = var.vault_api_port
-  #   instance_protocol = "TCP"
-  # }
-
   dynamic "listener" {
     for_each = toset(var.lb_listeners)
 

--- a/modules/vault-elb/main.tf
+++ b/modules/vault-elb/main.tf
@@ -45,12 +45,12 @@ resource "aws_elb" "vault" {
   # }
 
   dynamic "listener" {
-    for_each = toset(var.lb_ports)
+    for_each = toset(var.lb_listeners)
 
     content {
-      lb_port = listener.key
-      lb_protocol = "TCP"
-      instance_port = listener.key
+      lb_port           = listener.value["lb_port"]
+      lb_protocol       = "TCP"
+      instance_port     = listener.value["vault_api_port"]
       instance_protocol = "TCP"
     }
   }
@@ -93,10 +93,10 @@ resource "aws_security_group" "vault" {
 }
 
 resource "aws_security_group_rule" "allow_inbound_api" {
-  count = length(var.lb_ports)
+  count       = length(var.lb_listeners)
   type        = "ingress"
-  from_port   = var.lb_ports[count.index]
-  to_port     = var.lb_ports[count.index]
+  from_port   = lookup(var.lb_listeners[count.index], "lb_port")
+  to_port     = lookup(var.lb_listeners[count.index], "lb_port")
   protocol    = "tcp"
   cidr_blocks = var.allowed_inbound_cidr_blocks
 

--- a/modules/vault-elb/main.tf
+++ b/modules/vault-elb/main.tf
@@ -48,9 +48,9 @@ resource "aws_elb" "vault" {
     for_each = var.lb_ports
 
     content {
-      lb_port = lb_ports.key
+      lb_port = listener.key
       lb_protocol = "TCP"
-      instance_port = lb_ports.key
+      instance_port = listener.key
       instance_protocol = "TCP"
     }
   }

--- a/modules/vault-elb/main.tf
+++ b/modules/vault-elb/main.tf
@@ -93,9 +93,10 @@ resource "aws_security_group" "vault" {
 }
 
 resource "aws_security_group_rule" "allow_inbound_api" {
+  count = length(var.lb_ports)
   type        = "ingress"
-  from_port   = var.lb_port
-  to_port     = var.lb_port
+  from_port   = var.lb_ports[count.index]
+  to_port     = var.lb_ports[count.index]
   protocol    = "tcp"
   cidr_blocks = var.allowed_inbound_cidr_blocks
 

--- a/modules/vault-elb/main.tf
+++ b/modules/vault-elb/main.tf
@@ -45,7 +45,7 @@ resource "aws_elb" "vault" {
   # }
 
   dynamic "listener" {
-    for_each = var.lb_ports
+    for_each = toset(var.lb_ports)
 
     content {
       lb_port = listener.key

--- a/modules/vault-elb/main.tf
+++ b/modules/vault-elb/main.tf
@@ -24,7 +24,7 @@ resource "aws_elb" "vault" {
   security_groups = [aws_security_group.vault.id]
   subnets         = var.subnet_ids
 
-  # optional access_logs creation  
+  # optional access_logs creation
   dynamic "access_logs" {
     for_each = var.access_logs == null ? [] : ["once"]
 
@@ -37,11 +37,22 @@ resource "aws_elb" "vault" {
   }
 
   # Run the ELB in TCP passthrough mode
-  listener {
-    lb_port           = var.lb_port
-    lb_protocol       = "TCP"
-    instance_port     = var.vault_api_port
-    instance_protocol = "TCP"
+  # listener {
+  #   lb_port           = var.lb_port
+  #   lb_protocol       = "TCP"
+  #   instance_port     = var.vault_api_port
+  #   instance_protocol = "TCP"
+  # }
+
+  dynamic "listener" {
+    for_each = var.lb_ports
+
+    content {
+      lb_port = lb_ports.key
+      lb_protocol = "TCP"
+      instance_port = lb_ports.key
+      instance_protocol = "TCP"
+    }
   }
 
   health_check {

--- a/modules/vault-elb/variables.tf
+++ b/modules/vault-elb/variables.tf
@@ -65,15 +65,21 @@ variable "domain_name" {
 #   default     = 443
 # }
 
-variable "lb_ports" {
-  type = list(number)
-  default     = [443]
+variable "lb_listeners" {
+  description = "The ports that load balancer and vault listen on for API requests."
+  type = list(map(string))
+  default = [
+    {
+      lb_port = 443 # load balancer port
+      vault_api_port = 8200 # vault instance port
+    },
+  ]
 }
 
-variable "vault_api_port" {
-  description = "The port to listen on for API requests."
-  default     = 8200
-}
+# variable "vault_api_port" {
+#   description = "The port to listen on for API requests."
+#   default     = 8200
+# }
 
 variable "internal" {
   description = "If set to true, this will be an internal ELB, accessible only within the VPC. The main reason to use an ELB with Vault is to make it publicly accessible, so this should typically be set to false."

--- a/modules/vault-elb/variables.tf
+++ b/modules/vault-elb/variables.tf
@@ -67,10 +67,10 @@ variable "domain_name" {
 
 variable "lb_listeners" {
   description = "The ports that load balancer and vault listen on for API requests."
-  type = list(map(string))
+  type        = list(map(string))
   default = [
     {
-      lb_port = 443 # load balancer port
+      lb_port        = 443  # load balancer port
       vault_api_port = 8200 # vault instance port
     },
   ]
@@ -78,7 +78,7 @@ variable "lb_listeners" {
 
 variable "lb_healthcheck_vault_api_port" {
   description = "Vault API port used for load-balancer healthcheck"
-  default = 8200
+  default     = 8200
 }
 
 # variable "vault_api_port" {

--- a/modules/vault-elb/variables.tf
+++ b/modules/vault-elb/variables.tf
@@ -60,9 +60,14 @@ variable "domain_name" {
   default     = "replace-me"
 }
 
-variable "lb_port" {
-  description = "The port the load balancer should listen on for API requests."
-  default     = 443
+# variable "lb_port" {
+#   description = "The port the load balancer should listen on for API requests."
+#   default     = 443
+# }
+
+variable "lb_ports" {
+  type = list(number)
+  default     = [443]
 }
 
 variable "vault_api_port" {

--- a/modules/vault-elb/variables.tf
+++ b/modules/vault-elb/variables.tf
@@ -60,11 +60,6 @@ variable "domain_name" {
   default     = "replace-me"
 }
 
-# variable "lb_port" {
-#   description = "The port the load balancer should listen on for API requests."
-#   default     = 443
-# }
-
 variable "lb_listeners" {
   description = "The ports that load balancer and vault listen on for API requests."
   type        = list(map(string))
@@ -80,11 +75,6 @@ variable "lb_healthcheck_vault_api_port" {
   description = "Vault API port used for load-balancer healthcheck"
   default     = 8200
 }
-
-# variable "vault_api_port" {
-#   description = "The port to listen on for API requests."
-#   default     = 8200
-# }
 
 variable "internal" {
   description = "If set to true, this will be an internal ELB, accessible only within the VPC. The main reason to use an ELB with Vault is to make it publicly accessible, so this should typically be set to false."

--- a/modules/vault-elb/variables.tf
+++ b/modules/vault-elb/variables.tf
@@ -76,6 +76,11 @@ variable "lb_listeners" {
   ]
 }
 
+variable "lb_healthcheck_vault_api_port" {
+  description = "Vault API port used for load-balancer healthcheck"
+  default = 8200
+}
+
 # variable "vault_api_port" {
 #   description = "The port to listen on for API requests."
 #   default     = 8200


### PR DESCRIPTION
This change allows vault-elb module to add multiple listener instead of just one.