### PR TITLE
[INFRA-5035] - include variable for enabling protect_from_scale_in

### DIFF
--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -25,10 +25,11 @@ resource "aws_autoscaling_group" "autoscaling_group" {
   vpc_zone_identifier = var.subnet_ids
 
   # Use a fixed-size cluster
-  min_size             = floor(var.cluster_size / 3) < 1 ? 1 : floor(var.cluster_size / 3) + 1
-  max_size             = (var.cluster_size * 2) + 1
-  desired_capacity     = var.cluster_size
-  termination_policies = [var.termination_policies]
+  min_size              = floor(var.cluster_size / 3) < 1 ? 1 : floor(var.cluster_size / 3) + 1
+  max_size              = (var.cluster_size * 2) + 1
+  desired_capacity      = var.cluster_size
+  termination_policies  = [var.termination_policies]
+  protect_from_scale_in = var.protect_from_scale_in
 
   health_check_type         = var.health_check_type
   health_check_grace_period = var.health_check_grace_period

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -247,3 +247,9 @@ variable "iam_permissions_boundary" {
   type        = string
   default     = null
 }
+
+variable "protect_from_scale_in" {
+  description = "Whether newly launched instances are automatically protected from termination by Amazon EC2 Auto Scaling when scaling in."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
provide input variable to configure protect_from_scale_in on autoscaling group.

setting the default to false as it is not previously specified so the previous value was false.  we can potentially set the var in common-terraform vault-cluster to true so that our implementation sets it to true, but I would likely change that after all environments have it set to control the change roll out in gitops fashion.