### PR TITLE
[INFRA-5079] Provide variable to control ASG capacity rebalancing

### DIFF
--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -30,6 +30,7 @@ resource "aws_autoscaling_group" "autoscaling_group" {
   desired_capacity      = var.cluster_size
   termination_policies  = [var.termination_policies]
   protect_from_scale_in = var.protect_from_scale_in
+  capacity_rebalance    = var.capacity_rebalance
 
   health_check_type         = var.health_check_type
   health_check_grace_period = var.health_check_grace_period

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -255,7 +255,7 @@ variable "protect_from_scale_in" {
 }
 
 variable "capacity_rebalance" {
-  description = "(Optional) Whether capacity rebalance is enabled. Otherwise, capacity rebalance is disabled."
+  description = "(Optional) If enabled AWS ASG will attempt to proactively replace/terminate the Instances in your group that have received a rebalance recommendation to enhance availability by deploying across multiple instance types running in multiple Availability Zones"
   type        = bool
   default     = true
 }

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -253,3 +253,9 @@ variable "protect_from_scale_in" {
   type        = bool
   default     = false
 }
+
+variable "capacity_rebalance" {
+  description = "(Optional) Whether capacity rebalance is enabled. Otherwise, capacity rebalance is disabled."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
# Summary

In order to make node termination more predictable while manually unsealing nodes with shamir; providing a toggle for capacity rebalancing to be disabled.