### PR TITLE
[INFRA-5079] Set capacity_rebalance default value to false

### DIFF
--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -257,5 +257,5 @@ variable "protect_from_scale_in" {
 variable "capacity_rebalance" {
   description = "(Optional) If enabled AWS ASG will attempt to proactively replace/terminate the Instances in your group that have received a rebalance recommendation to enhance availability by deploying across multiple instance types running in multiple Availability Zones"
   type        = bool
-  default     = true
+  default     = false
 }


### PR DESCRIPTION
currently when not passed terraform is creating ASGs with capacity_rebalance set to null (from aws asg output); however in terraform this appears to result in a value of 
false by default.  setting the default behavior to match.

```
[11:31:15]❯ aws autoscaling describe-auto-scaling-groups | jq -r '.AutoScalingGroups[] | {name: .AutoScalingGroupName, cap: .CapacityRebalance}'
{
  "name": "mgmtnonprod-mgmt-vault-us-east-12021030920250362340000000c",
  "cap": null
}
